### PR TITLE
feat(client): implement inline editable titles for groups and wallets

### DIFF
--- a/packages/client/src/components/Title/index.tsx
+++ b/packages/client/src/components/Title/index.tsx
@@ -1,9 +1,90 @@
+import { useEffect, useRef, useState } from 'react'
+
 export type TitleProps = {
   title: string
+  suffix?: string
+  onChange?: (newTitle: string) => void
 }
 
-export const Title = ({ title }: TitleProps) => (
-  <h1 className="my-8 truncate text-4xl font-bold" tabIndex={0}>
-    {title}
-  </h1>
-)
+export const Title = ({ title, suffix, onChange }: TitleProps) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [value, setValue] = useState(title)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    setValue(title)
+  }, [title])
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  const startEditing = () => {
+    if (onChange) {
+      setIsEditing(true)
+    }
+  }
+
+  const stopEditing = () => {
+    setIsEditing(false)
+    const trimmedValue = value.trim()
+    if (trimmedValue && trimmedValue !== title && onChange) {
+      onChange(trimmedValue)
+    } else {
+      setValue(title)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      stopEditing()
+    } else if (e.key === 'Escape') {
+      setValue(title)
+      setIsEditing(false)
+    }
+  }
+
+  if (isEditing && onChange) {
+    return (
+      <div className="my-8 flex items-center text-4xl font-bold">
+        <div className="relative inline-flex max-w-full overflow-hidden">
+          <span className="pointer-events-none invisible whitespace-pre">
+            {value || ' '}
+          </span>
+          <input
+            ref={inputRef}
+            className="absolute inset-0 w-full bg-transparent p-0 ring-0 outline-none"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value)
+            }}
+            onBlur={stopEditing}
+            onKeyDown={handleKeyDown}
+          />
+        </div>
+        {suffix && <span className="ml-2 whitespace-nowrap">{suffix}</span>}
+      </div>
+    )
+  }
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <h1
+      className={`my-8 truncate text-4xl font-bold ${
+        onChange ? 'cursor-text transition-opacity hover:opacity-80' : ''
+      }`}
+      tabIndex={0}
+      onDoubleClick={startEditing}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') startEditing()
+      }}
+      title={onChange ? 'Double click to edit' : undefined}
+    >
+      {title}
+      {suffix && ` ${suffix}`}
+    </h1>
+  )
+}

--- a/packages/client/src/routes/group.$groupId.index.tsx
+++ b/packages/client/src/routes/group.$groupId.index.tsx
@@ -8,7 +8,7 @@ import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { Columns } from '@/components/Columns'
 import { Title } from '@/components/Title'
 import { CategoryFilterProvider } from '@/contexts/CategoryFilter'
-import { useOptionalGroup } from '@/contexts/RootStore/hooks/useGroup'
+import { useGroup, useOptionalGroup } from '@/contexts/RootStore/hooks/useGroup'
 import { Page } from '@/layout/Page'
 import { Route as DashboardRoute } from '@/routes/index'
 
@@ -29,6 +29,8 @@ const RouteComponent = () => {
   const { group } = useOptionalGroup({ groupId })
   const navigate = useNavigate()
 
+  const { setGroupName } = useGroup({ groupId })
+
   useEffect(() => {
     if (!group) void navigate({ to: DashboardRoute.to })
   }, [group, navigate])
@@ -45,7 +47,7 @@ const RouteComponent = () => {
           },
         ]}
       />
-      <Title title={group.name} />
+      <Title title={group.name} onChange={setGroupName} />
 
       <Columns className="md:grid-flow-col md:grid-rows-[auto_1fr] xl:grid-rows-none">
         <GroupInfoCard groupId={groupId} />

--- a/packages/client/src/routes/wallet.$walletId.index.tsx
+++ b/packages/client/src/routes/wallet.$walletId.index.tsx
@@ -7,7 +7,10 @@ import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { Columns } from '@/components/Columns'
 import { Title } from '@/components/Title'
 import { CategoryFilterProvider } from '@/contexts/CategoryFilter'
-import { useOptionalWallet } from '@/contexts/RootStore/hooks/useWallet'
+import {
+  useOptionalWallet,
+  useWallet,
+} from '@/contexts/RootStore/hooks/useWallet'
 import { Page } from '@/layout/Page'
 import { Route as GroupRoute } from '@/routes/group.$groupId.index'
 import { Route as DashboardRoute } from '@/routes/index'
@@ -28,6 +31,8 @@ const RouteComponent = () => {
   const { walletId } = Route.useParams()
   const { wallet } = useOptionalWallet({ walletId })
   const navigate = useNavigate()
+
+  const { setWalletName } = useWallet({ walletId })
 
   useEffect(() => {
     if (!wallet) void navigate({ to: DashboardRoute.to })
@@ -50,7 +55,11 @@ const RouteComponent = () => {
           },
         ]}
       />
-      <Title title={`${wallet.name} ${wallet.currency.symbol}`} />
+      <Title
+        title={wallet.name}
+        suffix={wallet.currency.symbol}
+        onChange={setWalletName}
+      />
 
       <Columns className="md:grid-flow-col md:grid-rows-[auto_1fr] lg:grid-rows-none">
         <WalletInfoCard walletId={walletId} />

--- a/packages/schemas/sync/schemas.ts
+++ b/packages/schemas/sync/schemas.ts
@@ -51,7 +51,7 @@ export const performSyncBodySchema = z.object({
 })
 
 export const performSyncResponseSchema = z.object({
-  lastTransactionId: z.string(),
+  lastTransactionId: z.string().nullable(),
 
   updates: z.object({
     currencies: z.array(

--- a/packages/server/routes/sync/index.ts
+++ b/packages/server/routes/sync/index.ts
@@ -184,7 +184,7 @@ const collect = async (
   userId: string,
   clientTransaction?: Modify<Transaction, { completedAt: Date }>,
 ): Promise<PerformSyncResponse> => {
-  const findLastTransaction = prisma.transaction.findFirstOrThrow({
+  const findLastTransaction = prisma.transaction.findFirst({
     where: { NOT: { completedAt: null } },
     orderBy: { completedAt: 'desc' },
     select: { id: true },
@@ -284,7 +284,7 @@ const collect = async (
   ])
 
   return {
-    lastTransactionId: lastTransaction.id,
+    lastTransactionId: lastTransaction?.id ?? null,
     updates: {
       currencies,
       users,


### PR DESCRIPTION
## Description
Implemented inline editing for Group and Wallet titles by double-clicking the title component.

This avoids navigating to the settings page just to rename these entities. It automatically syncs the update using the respective context setters.

- Added `onChange` and `suffix` props to `Title` component.
- Implemented a CSS absolute positioning trick to allow the input to auto-resize based on text width, keeping the `suffix` adjacent.
- Connected the `Title` to `setGroupName` and `setWalletName`.
- Fixed an issue during synchronization where `findFirstOrThrow` on the `Transaction` table caused a crash when the database was completely empty. Changed `lastTransactionId` to be nullable and used `findFirst` instead to gracefully handle the absence of prior transactions.

## Type of change
- [x] New feature
- [x] Bug fix